### PR TITLE
Keep the picker readable on narrow terminals

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,5 @@
+[default]
+locale = "en-us"
+
+[files]
+extend-exclude = ["*.tape"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ scrollback previews. When given root directories to search, it also lists any
 git or jj repositories beneath them. Selecting a session attaches to it;
 selecting a repository starts a numbered session inside it.
 
-<img width="2400" height="1120" alt="Animated demo of the zp session picker" src="https://github.com/user-attachments/assets/d8ddd986-57e0-49c2-9556-0280034287e0" />
+<img width="2400" height="1120" alt="Animated demo of the zp session picker" src="https://github.com/user-attachments/assets/6bcd625c-916c-48d0-92bb-e7176f2d5b6c" />
 
 [zmx]: https://github.com/neurosnap/zmx
 [fzf]: https://github.com/junegunn/fzf

--- a/demo/setup.sh
+++ b/demo/setup.sh
@@ -65,7 +65,7 @@ feat: bare bones OAuth workflow for publish is working
 feat: submit multiple scopes for the client
 refactor!: rename all of the media files
 refactor: use rel consistently as short version for relative (path)
-feat: add some type saftey to the group by values
+feat: add some type safety to the group by values
 feat: make mDNS discovery a bit more robust
 feat: distinguish between incoming/outgoing on media inventory
 fix: make sure we skip processed files when filtering
@@ -149,7 +149,7 @@ Make our emitted output naming consistent
 Add script index to our README documentation
 Rename emit_output to emit_github_output for clarity
 Refactor verify-checksums to use main() and structured helpers
-Refactor all scripts to standarize structure and docs
+Refactor all scripts to standardize structure and docs
 Use resolve_repo_root helper function consistently across scripts
 Update verify-checksums to handle multiple patterns
 Standardize format for usage placeholder values

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -156,7 +156,9 @@ fi
 
 out=$(HOME=$ZP_TEST_DIR "$zp" --candidates "$root")
 line=$(grep $'\t'"$root/plain"$'\t' <<<"$out")
-if [[ $line == *'~/root/plain'* && $line == *$'\t'"$root/plain"$'\t'* ]]; then
+display=${line##*$'\t'}
+if [[ $display == *'~/root'* && $display != *"$ZP_TEST_DIR"* &&
+	$line == *$'\t'"$root/plain"$'\t'* ]]; then
 	ok 'display paths shorten the home dir to ~ while values stay absolute'
 else
 	not_ok 'display paths shorten the home dir to ~ while values stay absolute' "$line"

--- a/zp
+++ b/zp
@@ -58,15 +58,18 @@ tilde() {
 }
 
 candidates() {
-	local name pid clients dir repo count note sdir
+	local name clients dir repo count note sdir width i
 	local session_dirs=()
+	local names=() notes=() session_clients=()
 
 	# Existing zmx sessions. Lines carry a marker prefix before
 	# name= (e.g. "→ " on the attached session), so strip through
-	# the field labels rather than off the front.
-	while IFS=$'\t' read -r name pid clients _ dir; do
+	# the field labels rather than off the front. Rows are buffered
+	# so the name column can be padded to the widest name instead
+	# of a fixed width.
+	width=0
+	while IFS=$'\t' read -r name _ clients _ dir; do
 		name=${name#*name=}
-		pid=${pid#*pid=}
 		clients=${clients#*clients=}
 		dir=${dir#*start_dir=}
 
@@ -82,17 +85,45 @@ candidates() {
 			note='→ '
 		fi
 
-		tilde "$dir"
-		printf 'session\t%s\t%s%-20s  pid:%-8s  clients:%-2s  %s\n' \
-			"$name" "$note" "$name" "$pid" "$clients" "$tilded"
+		names+=("$name")
+		notes+=("$note")
+		session_clients+=("$clients")
+		if [[ ${#name} -gt $width ]]; then
+			width=${#name}
+		fi
 	done < <(zmx list 2>/dev/null || true)
+
+	for ((i = 0; i < ${#names[@]}; i++)); do
+		tilde "${session_dirs[i]}"
+		printf 'session\t%s\t%s%-*s  clients:%-2s  %s\n' \
+			"${names[i]}" "${notes[i]}" "$width" "${names[i]}" \
+			"${session_clients[i]}" "$tilded"
+	done
 
 	# Repositories, when any search roots are configured: git
 	# (including linked worktrees where .git is a file) and jj
 	# (including workspaces, which may lack a .git). Colocated
-	# repos match both markers, so dedupe.
+	# repos match both markers, so dedupe. sort already buffers
+	# the whole scan, so collecting the rows to size the name
+	# column costs no extra latency.
+	local repos=()
 	if [[ ${#search_roots[@]} -gt 0 ]]; then
+		width=0
 		while IFS= read -r repo; do
+			repos+=("$repo")
+			name=${repo##*/}
+			if [[ ${#name} -gt $width ]]; then
+				width=${#name}
+			fi
+		done < <(
+			scan_repos |
+				sed -E 's,/\.(git|jj)/?$,,' |
+				sort -u
+		)
+	fi
+
+	if [[ ${#repos[@]} -gt 0 ]]; then
+		for repo in "${repos[@]}"; do
 			count=0
 			if [[ ${#session_dirs[@]} -gt 0 ]]; then
 				for sdir in "${session_dirs[@]}"; do
@@ -109,14 +140,16 @@ candidates() {
 				note=' (1 session)'
 			fi
 
-			tilde "$repo"
-			printf 'repo\t%s\t[repo] %-20s  %s%s\n' \
-				"$repo" "${repo##*/}" "$tilded" "$note"
-		done < <(
-			scan_repos |
-				sed -E 's,/\.(git|jj)/?$,,' |
-				sort -u
-		)
+			# The name column already shows the basename, so the
+			# path column shows only the parent directory.
+			dir=${repo%/*}
+			if [[ -z $dir ]]; then
+				dir=/
+			fi
+			tilde "$dir"
+			printf 'repo\t%s\t[repo] %-*s  %s%s\n' \
+				"$repo" "$width" "${repo##*/}" "$tilded" "$note"
+		done
 	fi
 }
 
@@ -231,16 +264,17 @@ select_session() {
 				--print-query \
 				--expect=ctrl-n \
 				--with-shell='sh -c' \
-				--height=80% \
+				--height=90% \
 				--reverse \
 				--multi \
 				--tiebreak=index \
+				--ellipsis='…' \
 				--prompt='zmx> ' \
 				--header=$'Enter: select/create | Tab: mark\n^N: new from query | ^X: kill' \
 				--bind="ctrl-x:execute-silent(printf '%s\n' {+} | $kill_cmd)+reload($reload_cmd)" \
 				--bind="focus:transform:test {1} = session && echo 'change-preview-window(follow)' || echo 'change-preview-window(nofollow)'" \
 				--preview="$preview_cmd" \
-				--preview-window=right:60%
+				--preview-window='right,60%,<55(down,50%)' # <N is the preview's own width: 55 ≈ a 92-column terminal
 	)
 	rc=$?
 	set -e


### PR DESCRIPTION
The left pane was easily cut off: fixed 20-column padding, a low-value pid column, and repo paths that repeated the basename shown right beside them.

Move the preview below the list when it would be narrower than 55 columns, pad each section's name column to its widest entry, drop the pid column, and show only the parent directory on repo rows. Truncate overflow with a one-character ellipsis and raise --height to 90% so the stacked layout has room.