### PR TITLE
Show a note instead of a recursive preview for the current session

### DIFF
--- a/tests/bin/zmx
+++ b/tests/bin/zmx
@@ -52,6 +52,9 @@ list)
 	fi
 	;;
 history)
+	# Logged separately from calls.log so the preview traffic never
+	# disturbs the attach/kill glob assertions.
+	echo "HISTORY:[$2]" >>"$ZP_TEST_DIR/history.log"
 	seq 1 300
 	;;
 *)

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -154,6 +154,24 @@ else
 	not_ok 'the session zp runs inside gets the arrow marker' "$beta_line"
 fi
 
+rm -f "$ZP_TEST_DIR/history.log"
+run '' "$esc" >/dev/null || true
+if [[ $(cat "$ZP_TEST_DIR/history.log" 2>/dev/null) == *'HISTORY:[alpha.1]'* ]]; then
+	ok 'focusing a session previews its history'
+else
+	not_ok 'focusing a session previews its history' \
+		"$(cat "$ZP_TEST_DIR/history.log" 2>/dev/null || true)"
+fi
+
+rm -f "$ZP_TEST_DIR/history.log"
+ZMX_SESSION=alpha.1 run '' "$esc" >/dev/null || true
+if [[ $(cat "$ZP_TEST_DIR/history.log" 2>/dev/null) != *'HISTORY:[alpha.1]'* ]]; then
+	ok 'the current session skips the recursive history preview'
+else
+	not_ok 'the current session skips the recursive history preview' \
+		"$(cat "$ZP_TEST_DIR/history.log" 2>/dev/null || true)"
+fi
+
 out=$(HOME=$ZP_TEST_DIR "$zp" --candidates "$root")
 line=$(grep $'\t'"$root/plain"$'\t' <<<"$out")
 display=${line##*$'\t'}

--- a/zp
+++ b/zp
@@ -233,7 +233,13 @@ select_session() {
 	# login shell. {1} is the candidate type, {2} its value.
 	local preview_cmd='
 		if test {1} = session; then
-			ZMX_SESSION_PREFIX= zmx history {2} | tail -n 200
+			if test {2} = "${ZMX_SESSION:-}"; then
+				# Previewing the session zp itself runs inside
+				# would just show this picker recursively.
+				echo "→ you are here (this is the current session)"
+			else
+				ZMX_SESSION_PREFIX= zmx history {2} | tail -n 200
+			fi
 		elif test -e {2}/.jj && command -v jj >/dev/null; then
 			jj -R {2} --ignore-working-copy --color always log -r :: --limit 50 \
 				-T "$ZP_JJ_LOG_TEMPLATE"


### PR DESCRIPTION
Previewing the session zp runs inside just captures the picker's own UI from the scrollback, and the follow binding tails it live as the cursor moves. Replace it with a one-line "you are here" note that echoes the arrow marker on the list row.

The zmx test shim now logs history calls to a separate file so the new preview assertions never disturb the attach/kill log globs.