### PR TITLE
End the demo inside the picker showing the current session

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ scrollback previews. When given root directories to search, it also lists any
 git or jj repositories beneath them. Selecting a session attaches to it;
 selecting a repository starts a numbered session inside it.
 
-<img width="2400" height="1120" alt="Animated demo of the zp session picker" src="https://github.com/user-attachments/assets/6bcd625c-916c-48d0-92bb-e7176f2d5b6c" />
+<img width="2400" height="1120" alt="Animated demo of the zp session picker" src="https://github.com/user-attachments/assets/c80ce837-25eb-4c1f-b394-d9f6f1daed54" />
 
 [zmx]: https://github.com/neurosnap/zmx
 [fzf]: https://github.com/junegunn/fzf

--- a/demo/bin/zmx
+++ b/demo/bin/zmx
@@ -4,10 +4,20 @@
 
 case $1 in
 list)
+	# After the tape's attach, $ZMX_SESSION names a session (e.g.
+	# whatchord.2) that the canned data doesn't know; list it as the
+	# attached one so the reopened picker shows a current session.
 	if [ "${2:-}" = "--short" ]; then
-		printf 'whatchord.1\nzmx-picker.1\nscratch\n'
+		printf 'whatchord.1\n'
+		if [ -n "${ZMX_SESSION:-}" ]; then
+			printf '%s\n' "$ZMX_SESSION"
+		fi
+		printf 'zmx-picker.1\nscratch\n'
 	else
 		printf '  name=whatchord.1\tpid=52341\tclients=0\tcreated=1\tstart_dir=%s/src/whatchord\n' "$HOME"
+		if [ -n "${ZMX_SESSION:-}" ]; then
+			printf '\342\206\222 name=%s\tpid=53347\tclients=1\tcreated=4\tstart_dir=%s/src/whatchord\n' "$ZMX_SESSION" "$HOME"
+		fi
 		printf '  name=zmx-picker.1\tpid=52502\tclients=0\tcreated=2\tstart_dir=%s/src/zmx-picker\n' "$HOME"
 		printf '  name=scratch\tpid=53113\tclients=0\tcreated=3\tstart_dir=%s\n' "$HOME"
 	fi

--- a/demo/demo.tape
+++ b/demo/demo.tape
@@ -46,3 +46,12 @@ Type "jj st"
 Sleep 500ms
 Enter
 Sleep 3s
+
+# Reopen the picker from inside the session: whatchord.2 carries
+# the arrow marker and a "you are here" preview.
+Type "zp"
+Sleep 500ms
+Enter
+Sleep 2.5s
+Down
+Sleep 4s

--- a/demo/env.sh
+++ b/demo/env.sh
@@ -5,5 +5,8 @@ sh demo/setup.sh
 export ZP_ROOT=/tmp/zp-demo/src
 export PATH="$PWD:$PWD/demo/bin:$PATH"
 export HOME=/tmp/zp-demo
+# The render may itself run inside a real zmx session; the demo
+# starts outside any, so drop the inherited session environment.
+unset ZMX_SESSION ZMX_SESSION_PREFIX
 export PS1='\n\w \[\e[38;2;250;179;135m\]❯\[\e[0m\] '
 cd "$HOME" || return


### PR DESCRIPTION
Rendering could inherit a real ZMX_SESSION through vhs, falsely arrow-marking a staged session, so the demo env now drops it. The fake zmx lists ZMX_SESSION as an attached session after the tape's repo selection creates whatchord.2, and the tape reopens zp from inside it to close on the arrow marker and "you are here" preview.